### PR TITLE
current user gets in the way of simplier FHIR queries

### DIFF
--- a/packages/fhirman/agents/assistant.ts
+++ b/packages/fhirman/agents/assistant.ts
@@ -21,7 +21,7 @@ export async function createAssistantAgent(): Promise<AssistantAgent> {
   const outputEmitter = new ModelOutputEmitter();
   const currentUser = await getCurrentUser();
 
-  const tools = [new FhirQuestion(currentUser, outputEmitter)];
+  const tools = [new FhirQuestion(outputEmitter)];
 
   const agentPrompt = await assistantPrompt(currentUser, tools);
 

--- a/packages/fhirman/agents/fhir.ts
+++ b/packages/fhirman/agents/fhir.ts
@@ -13,9 +13,7 @@ import { FhirAPIServer } from "../tools/FhirAPIServer.ts";
 import { FhirDocsToolkit } from "../tools/FhirDocsToolkit.ts";
 import { ModelOutputEmitter } from "../events/ModelOutputEmitter.ts"
 
-import { type CurrentUser } from "../helpers/currentUser.ts";
-
-export async function createFhirAgent(currentUser: CurrentUser, emitter: ModelOutputEmitter) {
+export async function createFhirAgent(emitter: ModelOutputEmitter) {
   const docsToolkit = new FhirDocsToolkit();
   const dateToolkit = new DateToolkit();
 
@@ -26,7 +24,7 @@ export async function createFhirAgent(currentUser: CurrentUser, emitter: ModelOu
   ];
 
   const llm = createOpenAIInstance({ temperature: 0 });
-  const prompt = await fhirQuestionPrompt(currentUser, tools);
+  const prompt = await fhirQuestionPrompt(tools);
   const llmChain = new LLMChain({
     llm,
     prompt,

--- a/packages/fhirman/prompts/fhirQuestionPrompt.ts
+++ b/packages/fhirman/prompts/fhirQuestionPrompt.ts
@@ -2,16 +2,7 @@ import { ZeroShotAgent } from "langchain/agents";
 import { PromptTemplate } from "langchain/prompts";
 import { Tool } from "langchain/tools";
 
-import { type CurrentUser } from "../helpers/currentUser.ts";
-
 const INSTRUCTIONS = `Your title is "FHIR Query Agent" and so is your name.  You are a data query agent.
-
-
-The human asking the questions is:
-name: {name}
-gender: {gender}
-resourceType: {resourceType}
-id: {id}
 
 You must answer the questions step-by-step by using the provided tools.  Don't skip any step.
 
@@ -65,14 +56,13 @@ This was your previous work (but I haven't seen any of it! I only see what you r
 {agent_scratchpad}`;
 
 export async function fhirQuestionPrompt(
-  currentUser: CurrentUser,
   tools: Tool[]
 ): Promise<PromptTemplate> {
   const instructionPrompt = new PromptTemplate({
     template: INSTRUCTIONS,
-    inputVariables: ["name", "gender", "resourceType", "id"],
+    inputVariables: [],
   });
-  const instructions = await instructionPrompt.format(currentUser);
+  const instructions = await instructionPrompt.format({});
   const prefix = instructions + EXTRA_INSTRUCTIONS;
 
   return ZeroShotAgent.createPrompt(tools, {

--- a/packages/fhirman/tools/FhirQuestion.ts
+++ b/packages/fhirman/tools/FhirQuestion.ts
@@ -3,8 +3,6 @@ import { AgentExecutor } from "langchain/agents";
 import { type ChainValues } from "langchain/schema";
 import { Tool } from "langchain/tools";
 
-import { CurrentUser } from "../helpers/currentUser.ts";
-
 import { createFhirAgent } from "../agents/fhir.ts";
 //@ts-ignore
 import { ModelOutputEmitter } from "../events/ModelOutputEmitter.ts"
@@ -15,19 +13,17 @@ export class FhirQuestion extends Tool {
     "Useful for answering questions about medical data stored on a FHIR RESTful API server.  The input to this tool should be a natural language query about some FHIR resource.  The output of this tool is the summarized Fhir RESTFul API server response.";
 
   executor: AgentExecutor | undefined;
-  currentUser: CurrentUser;
   emitter: ModelOutputEmitter;
 
-  constructor(currentUser: CurrentUser, emitter: ModelOutputEmitter) {
+  constructor(emitter: ModelOutputEmitter) {
     super();
 
-    this.currentUser = currentUser;
     this.emitter = emitter;
   }
 
   async _call(input: string): Promise<string> {
     if (!this.executor) {
-      this.executor = await createFhirAgent(this.currentUser, this.emitter);
+      this.executor = await createFhirAgent(this.emitter);
     }
 
     try {


### PR DESCRIPTION
# Why
_Having a current user in context is great, but needs to have better integration as it interferes with regular FHIR queries.  Removed here until further integration work is done_

## What was done
- [x] remove current user from the `FHIRQuestion` agent, for now.