### PR TITLE
chore: clear cache script plus safe session directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,27 @@
    Cmd + P and select 'Dev containers: rebuild containers without cache`.
 2. Then you can start querying the API at `http://localhost:8889`
 
-### Usage
+---
 
-Start the webserver project:
+## Usage
 
+### Start the webserver project:
+This will watch the project directory and restart as necessary.
 ```
 yarn chat
 ```
 
-Make sure that `sessions` directory exists under `workspace`, otherwise do
-
-```
-mkdir sessions
-```
-
-This will watch the project directory and restart as necessary.
-
-Start the UI component:
-
+### Start the UI component:
 ```
 yarn chat-styles
+```
+
+### Format the deno TS sourcecode:
+```
+yarn lint
+```
+
+### Clear the deno package cache:
+```
+yarn clear-cache
 ```

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "embed": "yarn workspace @bonfhir/campfhir-cli dev embed",
     "chat": "cd /workspace/deno/fhirchat-demo/ && deno task start",
     "chat-styles": "cd /workspace/deno/fhirchat-demo/ && deno task build:css",
-    "lint": "cd /workspace/deno/fhirchat-demo/ && deno fmt"
+    "lint": "cd /workspace/deno/fhirchat-demo/ && deno fmt",
+    "clear-cache": "cd /workspace/deno/fhirchat-demo/ && deno cache -r dev.ts"
   }
 }

--- a/packages/fhirman/helpers/sessionLogger.ts
+++ b/packages/fhirman/helpers/sessionLogger.ts
@@ -3,6 +3,7 @@
 // it is implemented using the singleton pattern
 
 import { createWriteStream, WriteStream } from "fs";
+import { mkdir } from 'node:fs/promises';
 
 const basePath = "/workspace/sessions/";
 
@@ -11,6 +12,8 @@ export class SessionLogger {
   private stream: WriteStream;
 
   private constructor(sessionParams: object) {
+    this.ensureSessionDirectory();
+
     const fileName = `${basePath}FhirAssistant_${new Date().getTime()}.log`;
     this.stream = createWriteStream(fileName);
 
@@ -18,6 +21,15 @@ export class SessionLogger {
     this.log("Session params:");
     this.log(JSON.stringify(sessionParams, null, 2));
     this.separator();
+  }
+
+  async ensureSessionDirectory() {
+    try {
+      return await mkdir(basePath);
+    } catch (error) {
+      if (error.code == "EEXIST") return true;
+      else throw(error);
+    }
   }
 
   public log(message: string, ...extra: any[]) {


### PR DESCRIPTION
# Why

_Because the session directory handling was not proper & sometimes deno asset cache needs to be refreshed_

## What was done

- [x] `yarn clear-cache` clears the _deno assets cache_
- [x] creates the `/workspace/sessions` directory on usage
- [x] adapt `readme` & `Dockerfile` to follow 👆   